### PR TITLE
Correct JSON example - address issue #114

### DIFF
--- a/draft-ietf-oauth-transaction-tokens.md
+++ b/draft-ietf-oauth-transaction-tokens.md
@@ -413,9 +413,9 @@ The figure below {{figleaftxtokenbody}} shows a non-normative example of the JWT
 
 ~~~ json
 {
-  "iat": "1686536226000",
+  "iat": 1686536226,
   "aud": "trust-domain.example",
-  "exp": "1686536526000",
+  "exp": 1686536586,
   "txn": "97053963-771d-49cc-a4e3-20aad399c312",
   "sub": "d084sdrt234fsaw34tr23t",
   "rctx": {


### PR DESCRIPTION
Correcting the JSON example to use NumericDate for `iat` and `exp` claims. Address issue #114