### PR TITLE
Strengthen prohibition on expanding scope

### DIFF
--- a/draft-ietf-oauth-transaction-tokens.md
+++ b/draft-ietf-oauth-transaction-tokens.md
@@ -571,7 +571,7 @@ When issuing replacement Txn-Tokens, a Txn-Token Service:
 
 * MAY enable modifications to asserted values that reduce the scope of permitted actions
 * MAY enable additional asserted values
-* SHOULD NOT enable modification to asserted values that expand the scope of permitted actions
+* MUST NOT enable modification to asserted values that expand the scope of permitted actions
 * MUST NOT modify `sub` and `aud` values of the Txn-Token in the request
 * MUST NOT remove any of the existing requesting workload identifiers from the `req_wl` field in the `rctx` claim of the Txn-Token
 * MUST NOT issue replacement Txn-token with lifetime exceeding the lifetime of the originally presented token


### PR DESCRIPTION
Update to be consistent in prohibition of extending the scope of an Access Token. See issue #164