### PR TITLE
Delete "represenntation"

### DIFF
--- a/draft-ietf-oauth-transaction-tokens.md
+++ b/draft-ietf-oauth-transaction-tokens.md
@@ -603,7 +603,7 @@ The requesting workload MUST ensure that it authenticates the Transaction Token 
 Txn-Tokens need to be communicated between workloads that depend upon them to authorize the request. Such workloads will often present HTTP {{RFC9110}} interfaces for being invoked by other workloads. This section specifies the HTTP header the invoking workload MUST use to communicate the Txn-Token to the invoked workload, when the invoked workload presents an HTTP interface. Note that the standard HTTP `Authorization` header MUST NOT be used because that may be used by the workloads to communicate channel authorization.
 
 ## Txn-Token HTTP Header {#txn-token-http-header}
-A workload that invokes another workload using HTTP and needs to present a Txn-Token to the invoked workload MUST use the HTTP Header `Txn-Token` to communicate the Txn-Token. The value of this header MUST be the JWT that represents the Txn-Token.
+A workload that invokes another workload using HTTP and needs to present a Txn-Token to the invoked workload MUST use the HTTP Header `Txn-Token` to communicate the Txn-Token. The value of this header MUST be the Txn-Token.
 
 # Security Considerations {#Security}
 


### PR DESCRIPTION
See Issue #230 

It may be that the entire sentence can be deleted, although in its current form it does reinforce that the Transaction token MUST be included.