### PR TITLE
Clarify "request_context"

### DIFF
--- a/draft-ietf-oauth-transaction-tokens.md
+++ b/draft-ietf-oauth-transaction-tokens.md
@@ -462,7 +462,7 @@ To request a Txn-Token the workload invokes the OAuth 2.0 {{RFC6749}} token endp
 
 The following additional parameters MAY be present in a Txn-Token Request:
 
-* `request_context` OPTIONAL. This parameter contains a base64url encoded JSON object which represents the context of this transaction. The parameter SHOULD be present and how the Transaction Token Service uses this parameter is out of scope for this specification.
+* `request_context` OPTIONAL. This parameter contains a base64url encoded JSON object which represents the context of this transaction. Use of this parameter is RECOMMENDED.
 * `request_details` OPTIONAL. This parameter contains a base64url encoded JSON object which represents additional details of the transaction that MUST remain immutable throughout the processing of the transaction by multiple workloads. The Transaction Token Service uses this information to construct the `tctx` claim.
 
 The requesting workload MUST authenticate its identity to the Transaction Token Service. The exact client authentication mechanism used is outside the scope of this specification.


### PR DESCRIPTION
See issue #228 

In addition, the "request_context" is optional, so making it a SHOULD be included feels like maybe it is not optional. Instead the PR proposes language that says it is "RECOMMENDED".

@tulshi @gffletch - please review.