### PR TITLE
`txn` remains unchanged in a replacement transaction token

### DIFF
--- a/draft-ietf-oauth-transaction-tokens.md
+++ b/draft-ietf-oauth-transaction-tokens.md
@@ -800,6 +800,7 @@ The authors would like to thank the contributors and the OAuth working group mem
 * Clarify role of transaction tokens in call chain (https://github.com/oauth-wg/oauth-transaction-tokens/issues/203)
 * Revise normative langugage for enforcement of token expiry (https://github.com/oauth-wg/oauth-transaction-tokens/issues/210)
 * Remove exp field from unsigend token (https://github.com/oauth-wg/oauth-transaction-tokens/issues/201)
+* Clarify that `txn`should remain unchanged when included in a replacement transaction token.
 
 ## Since Draft 05
 {:numbered="false"}


### PR DESCRIPTION
Seee #193