### PR TITLE
Update description of 'request_details' parameter

### DIFF
--- a/draft-ietf-oauth-transaction-tokens.md
+++ b/draft-ietf-oauth-transaction-tokens.md
@@ -720,6 +720,7 @@ The authors would like to thank the contributors and the OAuth working group mem
 * Removed the requirement to encode parameters in based64url format
 * Rename the `purpose` claim to `scope`
 * Removed references to replacing transaction tokens, and added a note in the Security Considerations to clarify replacement concerns.
+* Clarify request_details (https://github.com/oauth-wg/oauth-transaction-tokens/issues/197)
 
 ## Since Draft 05
 {:numbered="false"}


### PR DESCRIPTION
Clarified the purpose of the 'request_details' parameter in the Txn-Token Request. See issue #197