### PR TITLE
Standardize terminology for Call Chain in document

### DIFF
--- a/draft-ietf-oauth-transaction-tokens.md
+++ b/draft-ietf-oauth-transaction-tokens.md
@@ -548,8 +548,6 @@ Once the Txn-Token is determined to be valid, the workload MAY use any of the da
 ## Txn-Token Replay Risks {#lifetime}
 A Txn-Token is not resistant to replay attacks. A long-lived Txn-Token therefore represents a risk if it is discovered by an attacker (e.g. if it is stored in a file), and then replayed. For this reason, a Txn-Token lifetime MUST be kept short and follow the guidance given in {{txn-token-lifetime}}.
 
-{{replace}} describes the TTS responsibilities when replacing a Txn-Token, including guidance to minimize the risk of replaying a Txn-Token to obtain one with an extended expiry.
-
 The use of a unique transaction identifier (`txn` claim) allows for discovery of Txn-Token replay as described in {{uti}}.
 
 ## Unique Transaction Identifier {#uti}


### PR DESCRIPTION
Updated terminology for consistency and clarity throughout the document, specifically changing 'call chain' to 'Call Chain' and ensuring proper capitalization.

I updated the terminology definition for `Call Chain` and `Subject Token Types`.

Carefull review required.