### PR TITLE
Update draft with editorial text and changes from 07 to 08

### DIFF
--- a/draft-ietf-oauth-transaction-tokens.md
+++ b/draft-ietf-oauth-transaction-tokens.md
@@ -709,6 +709,11 @@ The authors would like to thank John Bradley, Kelley Burgin, Brian Campbell, Nav
 ## Since Draft 08
 {:numbered="false"}
 
+* Editorial text describing claims
+
+## Since Draft 08
+{:numbered="false"}
+
 * Added document history for changes from 07 to 08
 * Added TTS Issuance Guidance policies (see issue https://github.com/oauth-wg/oauth-transaction-tokens/issues/321)
 * Provide guidance on cross-domain access (see https://github.com/oauth-wg/oauth-transaction-tokens/issues/326)


### PR DESCRIPTION
Added editorial text to describe claims and updated document history with changes from draft 07 to 08, including TTS Issuance Guidance policies and security considerations.